### PR TITLE
Initial plus

### DIFF
--- a/components/Turnstile.vue
+++ b/components/Turnstile.vue
@@ -1,65 +1,65 @@
 <template>
   <VueTurnstile
     v-model="token"
+    :reset-interval="resetInterval"
+    :size="size"
+    :theme="theme"
+    :action="action"
+    :appearance="appearance"
+    :render-on-mount="renderOnMount"
     :site-key="siteKey" />
 </template>
-<script>
+
+<script setup>
 /*!
   * Copyright (c) 2023 Digital Bazaar, Inc. All rights reserved.
   */
 import {config} from '@bedrock/web';
-import {defineEmits, ref, watch} from 'vue';
+import {defineEmits, defineProps, ref, watch} from 'vue';
 import VueTurnstile from 'vue-turnstile';
 
-export default {
-  name: 'Turnstile',
-  components: {VueTurnstile},
-  props: {
-    modelValue: {
-      type: String,
-      required: true,
-    },
-    resetInterval: {
-      type: Number,
-      required: false,
-    },
-    size: {
-      type: String,
-      required: false,
-    },
-    theme: {
-      type: String,
-      required: false,
-    },
-    action: {
-      type: String,
-      required: false,
-    },
-    appearance: {
-      type: String,
-      required: false,
-    },
-    renderOnMount: {
-      type: Boolean,
-      required: false,
-    },
+const props = defineProps({
+  modelValue: {
+    type: String,
+    required: true,
   },
-
-  setup() {
-    const token = ref('');
-    // siteKey is not a secret
-    const siteKey = ref(config.turnstile.siteKey);
-
-    const emit = defineEmits(['update:modelValue'])
-    watch(
-      () => token.value,
-      tokenValue => emit('update:modelValue', tokenValue));
-
-    return {
-      token,
-      siteKey,
-    }
+  resetInterval: {
+    default: 295000,
+    type: Number,
+    required: false,
+  },
+  size: {
+    default: 'normal',
+    type: String,
+    required: false,
+  },
+  theme: {
+    default: 'auto',
+    type: String,
+    required: false,
+  },
+  action: {
+    default: '',
+    type: String,
+    required: false,
+  },
+  appearance: {
+    default: 'always',
+    type: String,
+    required: false,
+  },
+  renderOnMount: {
+    default: true,
+    type: Boolean,
+    required: false,
   }
-};
+});
+
+const token = ref('');
+// siteKey is not a secret
+const siteKey = ref(config.turnstile.siteKey);
+
+const emit = defineEmits(['update:modelValue'])
+watch(token, tokenValue => emit('update:modelValue', tokenValue));
 
 </script>

--- a/components/Turnstile.vue
+++ b/components/Turnstile.vue
@@ -1,12 +1,6 @@
 <template>
   <VueTurnstile
     v-model="token"
-    :reset-interval="resetInterval"
-    :size="size"
-    :theme="theme"
-    :action="action"
-    :appearance="appearance"
-    :render-on-mount="renderOnMount"
     :site-key="siteKey" />
 </template>
 <script>
@@ -14,7 +8,7 @@
   * Copyright (c) 2023 Digital Bazaar, Inc. All rights reserved.
   */
 import {config} from '@bedrock/web';
-import {defineEmits, ref, watch} from 'vue';
+// import {defineEmits, ref, watch} from 'vue';
 import VueTurnstile from 'vue-turnstile';
 
 export default {
@@ -50,7 +44,13 @@ export default {
       required: false,
     },
   },
-
+  data() {
+    return {
+      siteKey: config.turnstile.siteKey,
+      token: ''
+    }
+  }
+  /*
   setup() {
     const token = ref('');
     // siteKey is not a secret
@@ -66,6 +66,7 @@ export default {
       siteKey,
     }
   }
+  */
 };
 
 </script>

--- a/components/Turnstile.vue
+++ b/components/Turnstile.vue
@@ -8,7 +8,7 @@
   * Copyright (c) 2023 Digital Bazaar, Inc. All rights reserved.
   */
 import {config} from '@bedrock/web';
-// import {defineEmits, ref, watch} from 'vue';
+import {defineEmits, ref, watch} from 'vue';
 import VueTurnstile from 'vue-turnstile';
 
 export default {
@@ -44,13 +44,7 @@ export default {
       required: false,
     },
   },
-  data() {
-    return {
-      siteKey: config.turnstile.siteKey,
-      token: ''
-    }
-  }
-  /*
+
   setup() {
     const token = ref('');
     // siteKey is not a secret
@@ -66,7 +60,6 @@ export default {
       siteKey,
     }
   }
-  */
 };
 
 </script>


### PR DESCRIPTION
@gannan08 @mandyvenables 

The code that is currently on `intiial` does not render the component in the browser.

With this change, the component will render/display on the browser.

When one clicks the checkbox in the component (captcha), the browser console shows `TypeError: emit is not a function`

The browser console gets cleared at some point which wipes out this message:

```
runtime-core.esm-bundler.js:179 [Vue warn]: defineEmits() is a compiler-hint helper that is only usable inside <script setup> of a single file component. Its arguments should be compiled away and passing it at runtime has no effect. 
  at <Turnstile modelValue="" onUpdate:modelValue=fn site-key="3x00000000000000000000FF" > 
  at <RegisterForm key=4 ref="registerModule" loading=false  ... > 
  at <SetupStepper loading=false installed=false skip-install-page=true  ... > 
  at <HomePage account="" onRetry=fn onVnodeUnmounted=fn<onVnodeUnmounted>  ... > 
  at <RouterView account="" onRetry=fn > 
  at <QPageContainer class="bg-white no-padding-top column col-grow" style= {max-height: '700px'} > 
  at <QLayout id="app" view="lHr LpR lFr" class="column q-mx-auto q-my-auto" > 
  at <WalletApp> 
  at <App>
```